### PR TITLE
NIM-8 Configure pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.egg-info
 .pytest_cache/
 .coverage
+test_readme.py

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+from pytest_readme import setup
+
+
+setup()

--- a/nim/app.py
+++ b/nim/app.py
@@ -1,4 +1,4 @@
-from flask import (
+from flask import (  # pylint: disable=F0401
     jsonify,
     render_template,
     session,

--- a/nim/tests/test_temp.py
+++ b/nim/tests/test_temp.py
@@ -1,6 +1,8 @@
+# pylint: disable=redefined-outer-name
+import pytest  # pylint: disable=F0401
+
 from nim.exceptions import NimException
 from nim.game import Nim
-import pytest
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,9 @@ deps =
     pytest-readme
     pytest-remove-stale-bytecode
     pytest-spec
+    pytest-travis-fold
     pytest-verbose-parametrize
+passenv = TRAVIS
 
 [testenv:bandit]
 # Ignore return code of Bandit for now to not make the build fail.

--- a/tox.ini
+++ b/tox.ini
@@ -16,31 +16,25 @@ commands =
     # Ignore return code of pep257 for now to not make the build fail.
     # TODO: Remove the dash once we've fixed all the issues.
     - pep257
+    # Ignore return code of eradicate for now to not make the build fail.
+    # TODO: Remove the dash once we've fixed all the issues.
+    - eradicate --recursive .
 deps =
+    eradicate
     flake8
     pep257
     pylint
 
 [testenv:test]
+# The -v option for pytest is required for the pytest-random-order package to
+# work.
 commands =
-    # pytest-random-order prints a traceback about an issue with
-    # pytest-eradicate, so running eradicate first separately with
-    # pytest-random-order disabled, and then calling pytest with the rest of
-    # the tests.
-    # It does not seem to affect the duration of the tests too much, but if
-    # this changes we should consider dropping one of the two plugins.
-    # Ignore return code of eradicate for now to not make the build fail.
-    # TODO: Remove the dash once we've fixed all the issues.
-    - pytest --eradicate --random-order-bucket=none {posargs}
-    # The -v option for pytest is required for the pytest-random-order package
-    # to work.
     pytest -v --spec --cov=./ {posargs}
 deps =
     flask
     mock
     pytest
     pytest-cov
-    pytest-eradicate
     pytest-random-order
     pytest-spec
     pytest-verbose-parametrize

--- a/tox.ini
+++ b/tox.ini
@@ -29,13 +29,14 @@ deps =
 # The -v option for pytest is required for the pytest-random-order package to
 # work.
 commands =
-    pytest -v --spec --cov=./ {posargs}
+    pytest -v --spec --doctest-modules --cov=./ {[tox]app} {posargs}
 deps =
     flask
     mock
     pytest
     pytest-cov
     pytest-random-order
+    pytest-readme
     pytest-spec
     pytest-verbose-parametrize
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37-dev,py3}, lint, test, bandit
+envlist = py{36,37-dev,py3}, lint, test, security
 skipsdist = True
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 app = nim
@@ -46,11 +46,15 @@ deps =
 passenv = TRAVIS  # Required for pytest-travis-fold
 whitelist_externals = rm
 
-[testenv:bandit]
-# Ignore return code of Bandit for now to not make the build fail.
-# TODO: Remove the dash once we've fixed all the issues.
-commands = - bandit -r {[tox]app}
-deps = bandit
+[testenv:security]
+commands =
+    # Ignore return code of Bandit for now to not make the build fail.
+    # TODO: Remove the dash once we've fixed all the issues.
+     - bandit -r {[tox]app}
+     pyt -f {[tox]app}/app.py
+deps =
+    bandit
+    taint-analysis
 
 [testenv:cleanup]
 commands =
@@ -66,6 +70,6 @@ whitelist_externals =
 
 [travis]
 python =
-    3.6: py36, lint, test, bandit
+    3.6: py36, lint, test, security
     3.7-dev: py37-dev, test
     pypy3: pypy3, test

--- a/tox.ini
+++ b/tox.ini
@@ -18,12 +18,15 @@ commands = - pylint {[tox]app}
 deps = pylint
 
 [testenv:test]
+# The -v option for pytest is required for the pytest-random-order package to
+# work.
 commands =
-    pytest --cov=./ {posargs}
+    pytest -v --cov=./ {posargs}
 deps =
     mock
     pytest
     pytest-cov
+    pytest-random-order
     flask
 
 [testenv:bandit]

--- a/tox.ini
+++ b/tox.ini
@@ -23,12 +23,13 @@ deps = pylint
 commands =
     pytest -v --spec --cov=./ {posargs}
 deps =
+    flask
     mock
     pytest
     pytest-cov
     pytest-random-order
     pytest-spec
-    flask
+    pytest-verbose-parametrize
 
 [testenv:bandit]
 # Ignore return code of Bandit for now to not make the build fail. Remove the

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ deps =
 # work.
 commands =
     pytest -v --spec --doctest-modules --cov=./ {[tox]app} {posargs}
+    # Remove the file created by pytest-readme after running pytest
+    rm test_readme.py
 deps =
     flask
     mock
@@ -42,6 +44,7 @@ deps =
     pytest-travis-fold
     pytest-verbose-parametrize
 passenv = TRAVIS
+whitelist_externals = rm
 
 [testenv:bandit]
 # Ignore return code of Bandit for now to not make the build fail.

--- a/tox.ini
+++ b/tox.ini
@@ -12,28 +12,38 @@ commands = flake8 --max-line-length 99 --max-complexity 12 {[tox]app}
 deps = flake8
 
 [testenv:pylint]
-# Ignore return code of Pylint for now to not make the build fail. Remove the
-# dash once we've fixed all the issues.
+# Ignore return code of Pylint for now to not make the build fail.
+# TODO: Remove the dash once we've fixed all the issues.
 commands = - pylint {[tox]app}
 deps = pylint
 
 [testenv:test]
-# The -v option for pytest is required for the pytest-random-order package to
-# work.
 commands =
+    # pytest-random-order prints a traceback about an issue with
+    # pytest-eradicate, so running eradicate first separately with
+    # pytest-random-order disabled, and then calling pytest with the rest of
+    # the tests.
+    # It does not seem to affect the duration of the tests too much, but if
+    # this changes we should consider dropping one of the two plugins.
+    # Ignore return code of eradicate for now to not make the build fail.
+    # TODO: Remove the dash once we've fixed all the issues.
+    - pytest --eradicate --random-order-bucket=none {posargs}
+    # The -v option for pytest is required for the pytest-random-order package
+    # to work.
     pytest -v --spec --cov=./ {posargs}
 deps =
     flask
     mock
     pytest
     pytest-cov
+    pytest-eradicate
     pytest-random-order
     pytest-spec
     pytest-verbose-parametrize
 
 [testenv:bandit]
-# Ignore return code of Bandit for now to not make the build fail. Remove the
-# dash once we've fixed all the issues.
+# Ignore return code of Bandit for now to not make the build fail.
+# TODO: Remove the dash once we've fixed all the issues.
 commands = - bandit -r {[tox]app}
 deps = bandit
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = py{36,37-dev,py3},lint,test,bandit
-skipsdist=True
+envlist = py{36,37-dev,py3}, lint, test, bandit
+skipsdist = True
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 app = nim
 
@@ -26,9 +26,9 @@ deps =
     pylint
 
 [testenv:test]
-# The -v option for pytest is required for the pytest-random-order package to
-# work.
 commands =
+    # The -v option for pytest is required for the pytest-random-order package
+    # to work.
     pytest -v --spec --doctest-modules --cov=./ {[tox]app} {posargs}
     # Remove the file created by pytest-readme after running pytest
     rm test_readme.py
@@ -43,7 +43,7 @@ deps =
     pytest-spec
     pytest-travis-fold
     pytest-verbose-parametrize
-passenv = TRAVIS
+passenv = TRAVIS  # Required for pytest-travis-fold
 whitelist_externals = rm
 
 [testenv:bandit]

--- a/tox.ini
+++ b/tox.ini
@@ -21,12 +21,13 @@ deps = pylint
 # The -v option for pytest is required for the pytest-random-order package to
 # work.
 commands =
-    pytest -v --cov=./ {posargs}
+    pytest -v --spec --cov=./ {posargs}
 deps =
     mock
     pytest
     pytest-cov
     pytest-random-order
+    pytest-spec
     flask
 
 [testenv:bandit]

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ deps =
     pytest-cov
     pytest-random-order
     pytest-readme
+    pytest-remove-stale-bytecode
     pytest-spec
     pytest-verbose-parametrize
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37-dev,py3},flake8,pylint,test,bandit
+envlist = py{36,37-dev,py3},lint,test,bandit
 skipsdist=True
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 app = nim
@@ -7,15 +7,19 @@ app = nim
 [testenv]
 use_develop = True
 
-[testenv:flake8]
-commands = flake8 --max-line-length 99 --max-complexity 12 {[tox]app}
-deps = flake8
-
-[testenv:pylint]
-# Ignore return code of Pylint for now to not make the build fail.
-# TODO: Remove the dash once we've fixed all the issues.
-commands = - pylint {[tox]app}
-deps = pylint
+[testenv:lint]
+commands =
+    flake8 --max-line-length 99 --max-complexity 12 {[tox]app}
+    # Ignore return code of Pylint for now to not make the build fail.
+    # TODO: Remove the dash once we've fixed all the issues.
+    - pylint {[tox]app}
+    # Ignore return code of pep257 for now to not make the build fail.
+    # TODO: Remove the dash once we've fixed all the issues.
+    - pep257
+deps =
+    flake8
+    pep257
+    pylint
 
 [testenv:test]
 commands =
@@ -61,6 +65,6 @@ whitelist_externals =
 
 [travis]
 python =
-    3.6: py36, flake8, pylint, test, bandit
+    3.6: py36, lint, test, bandit
     3.7-dev: py37-dev, test
     pypy3: pypy3, test


### PR DESCRIPTION

`pytest`:
- Simplify our tests using `@pytest.mark.parametrize` and make its
  output more verbose using `pytest-verbose-parametrize`.
- Test code in docstrings using `--doctest-modules`.

`pytest` plugins:
- Run the tests in a random order to reveal unwanted coupling between
  tests using `pytest-random-order`.
- Prettier `pytest` output using `pytest-spec`.
- Test code in the `README` using `pytest-readme`. Created
  `conftest.py`as this is required for `pytest-readme` to work.
- Remove stale bytecode before running tests using
  `pytest-remove-stale-bytecode`.
- Fold captured output on Travis using `pytest-travis-fold`.

`tox` environments:
- Create `lint` environment, add `pep257` to check docstrings and `eradicate` to find commented out code.
- Create `security` environment and add `pyt`.

Other:
- Make `pylint` happier by disabling a few errors.