### PR TITLE
Fix coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps = pylint
 
 [testenv:test]
 commands =
-    pytest --cov=./ {posargs}
+    pytest --cov={[tox]app} {posargs}
 deps =
     mock
     pytest


### PR DESCRIPTION
Just realized that the coverage reported results for packages inside the
.tox directory. This commit will now only report coverage for files
inside the nim directory.