### PR TITLE
Add classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,30 @@
 #!/usr/bin/env python
 from setuptools import find_packages, setup
 
+CLASSIFIERS = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Environment :: Web Environment",
+    "Framework :: Flake8",
+    "Framework :: Flask",
+    "Framework :: Pytest",
+    "Natural Language :: English",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: JavaScript",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Topic :: Games/Entertainment :: Board Games",
+]
+
 setup(
     name='nim',
     version='1.0',
     description='Web app for playing Nim',
     author='Hacksaurz',
-    #author_email='drunk@yourwedding.com',
+    # author_email='drunk@yourwedding.com',
     url='https://github.com/hacksaurz/nim',
     packages=find_packages(exclude=['*.tests']),
+    classifiers=CLASSIFIERS,
     install_requires=[
         'click==6.7',
         'Flask==0.12.2',


### PR DESCRIPTION
This may fix the issue that landscape.io is having when testing our app.

The issue could be https://github.com/landscapeio/landscape-issues/issues/300
and one of the reason it could be failing is that if we don't specify
Python 3, landscape.io will assume Python 2:
https://github.com/landscapeio/landscape-docs/blob/master/configuration.rst#python-targets-2-3

One way to fix that is to add classifiers to setup.py to explicitely say
we need Python 3. And while I was at it, I also added classifiers that I
thought were relevant. The list of available classifiers can be found at
https://pypi.python.org/pypi?%3Aaction=list_classifiers