### PR TITLE
Build on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       language: generic
       before_install:
         - brew update
-        - brew install python3
+        - brew upgrade python
         - virtualenv env -p python3
         - source env/bin/activate
 install: pip install codecov tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,21 @@ python:
   - "3.6"
   - "3.7-dev"
   - "pypy3"
-# Taken from https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-289140791
+# Taken from https://github.com/oz123/pytest-localftpserver
 matrix:
   include:
     - os: osx
       language: generic
+      python: 3.6
       before_install:
-        - brew update
-        - brew upgrade python
-        - brew install python@2
-        - virtualenv venv -p python3
-        - source venv/bin/activate
+        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - conda create -n py36 python=3.6 -y
+      install:
+        - source activate py36
+        - pip install tox
+        - conda install -y --name py36 virtualenv
 install: pip install codecov tox-travis
 env:
   - TOX_SKIP_MISSING_INTERPRETERS=False

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,17 @@ python:
   - "3.6"
   - "3.7-dev"
   - "pypy3"
+# Taken from https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-289140791
+matrix:
+  include:
+    - os: linux
+    - os: osx
+      language: generic
+      before_install:
+        - brew update
+        - brew install python3
+        - virtualenv env -p python3
+        - source env/bin/activate
 install: pip install codecov tox-travis
 env:
   - TOX_SKIP_MISSING_INTERPRETERS=False

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
         - source activate py36
         - pip install tox
         - conda install -y --name py36 virtualenv
+      script: tox -e py36,lint,lint-not-windows,test,security
 install: pip install codecov tox-travis
 env:
   - TOX_SKIP_MISSING_INTERPRETERS=False

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,13 @@ python:
 matrix:
   include:
     - os: osx
-      sudo: required
       language: generic
-      python: 3.6
-install: |
-  if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
-      brew update;
-      brew upgrade python;
-      python3 -m pip install --upgrade tox tox-travis
-  else
-      pip install --upgrade tox tox-travis
-  fi
+      before_install:
+        - brew update
+        - brew install python3
+        - virtualenv venv -p python3
+        - source venv/bin/activate
+install: pip install codecov tox-travis
 env:
   - TOX_SKIP_MISSING_INTERPRETERS=False
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
       before_install:
         - brew update
         - brew upgrade python
-        - virtualenv env -p python3
-        - source env/bin/activate
+        - python3 -m venv venv
+        - source venv/bin/activate
 install: pip install codecov tox-travis
 env:
   - TOX_SKIP_MISSING_INTERPRETERS=False

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,17 @@ python:
 matrix:
   include:
     - os: osx
+      sudo: required
       language: generic
-      before_install:
-        - brew update
-        - brew upgrade python
-        - python3 -m venv venv
-        - source venv/bin/activate
-install: pip install codecov tox-travis
+      python: 3.6
+install: |
+  if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
+      brew update;
+      brew upgrade python;
+      python3 -m pip install --upgrade tox tox-travis
+  else
+      pip install --upgrade tox tox-travis
+  fi
 env:
   - TOX_SKIP_MISSING_INTERPRETERS=False
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
       before_install:
         - brew update
         - brew upgrade python
+        - brew install python@2
         - virtualenv venv -p python3
         - source venv/bin/activate
 install: pip install codecov tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 # Taken from https://github.com/travis-ci/travis-ci/issues/2312#issuecomment-289140791
 matrix:
   include:
-    - os: linux
     - os: osx
       language: generic
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
       language: generic
       before_install:
         - brew update
-        - brew install python3
+        - brew upgrade python
         - virtualenv venv -p python3
         - source venv/bin/activate
 install: pip install codecov tox-travis


### PR DESCRIPTION
It's dirty because Travis doesn't officially support Python on OSX, I've tried a few ways (see commits if you want to see the horror).
I can see 3 things wrong with how this works:
1. Hardcoded version 3.6 for Python, ideally we should mimic what we do on Linux
2. Using Miniconda only because I couldn't get it to work without it, seems overkill
3. Manually specifying the list of tox environments to run so the build doesn't fail when it can't find Python 3.7 or pypy, which means we'll need to update that list if we modify `tox.ini`, sigh

But heh, [it works](https://travis-ci.org/hacksaurz/nim/builds/372843734).