### PR TITLE
Fix bandit and eradicate plus some reorg

### DIFF
--- a/.bandit.yml
+++ b/.bandit.yml
@@ -1,2 +1,4 @@
 exclude_dirs:
   - '/tests/'
+skips:
+  - B311  # Ignore warnings about standard pseudo-random generators

--- a/.bandit.yml
+++ b/.bandit.yml
@@ -1,4 +1,4 @@
 exclude_dirs:
-  - '/tests/'
+  - tests
 skips:
   - B311  # Ignore warnings about standard pseudo-random generators

--- a/nim/__init__.py
+++ b/nim/__init__.py
@@ -1,0 +1,8 @@
+from flask import Flask
+
+from nim.game import Nim
+
+
+app = Flask(__name__)
+app.secret_key = 'super secret key'
+app.game = Nim()

--- a/nim/game.py
+++ b/nim/game.py
@@ -81,7 +81,8 @@ class Chaos(Bot):
     """
     def move_strategy(self, state):
         """
-        Takes the state of the game and returns the result of another bot's move
+        Takes the state of the game and returns the result of another bot's
+        move
         """
         not_chaos_bot = [bot for bot in Bot.subclasses if bot != Chaos]
         chosen_bot = choice(not_chaos_bot)()
@@ -105,8 +106,8 @@ class Nim():
         """
         if not all(isinstance(x, int) and NUM_LIMIT_MIN <= x <= NUM_LIMIT_MAX
                    for x in (min, max, piles)):
-            raise NimException(
-                f"Please use integers between {NUM_LIMIT_MIN} and {NUM_LIMIT_MAX}")
+            raise NimException(f"Please use integers between {NUM_LIMIT_MIN} "
+                               "and {NUM_LIMIT_MAX}")
         elif min > max:
             raise NimException(
                 f"Min({min}) cant be greater than Max({max})")

--- a/nim/tests/test_routes.py
+++ b/nim/tests/test_routes.py
@@ -3,7 +3,7 @@ import json
 
 import pytest  # pylint: disable=F0401
 
-from nim.app import app
+from nim import app
 from nim.game import (
     NUM_LIMIT_MIN,
     NUM_LIMIT_MAX,

--- a/nim/views.py
+++ b/nim/views.py
@@ -2,16 +2,11 @@ from flask import (  # pylint: disable=F0401
     jsonify,
     render_template,
     session,
-    Flask,
     request,
 )
 
+from nim import app
 from nim.exceptions import NimException
-from nim.game import Nim
-
-app = Flask(__name__)
-app.secret_key = 'super secret key'
-app.game = Nim()
 
 
 @app.route('/')
@@ -24,8 +19,6 @@ def index():
 @app.route('/update')
 def update_game_state():
     state = session['state']
-    # player_move = loads('{"pile": 0, "stones": 1}')
-    # app.game.update(state, player_move)
     bot_move = app.game.chaos.move(state)
     app.game.update(state, bot_move)
     session['state'] = state
@@ -44,7 +37,3 @@ def new_game():
         return jsonify({'error': e.args}), 400
     session['state'] = state
     return jsonify({'state': state})
-
-
-if __name__ == '__main__':
-    app.run(debug=True)

--- a/run.py
+++ b/run.py
@@ -1,4 +1,0 @@
-from nim.app import app
-
-
-app.run(debug=True)

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+export FLASK_APP=nim/views.py
+export FLASK_ENV=development
+flask run

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     version='1.0',
     description='Web app for playing Nim',
     author='Hacksaurz',
-    # author_email='drunk@yourwedding.com',
     url='https://github.com/hacksaurz/nim',
     packages=find_packages(exclude=['*.tests']),
     classifiers=CLASSIFIERS,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37-dev,py3}, lint, lint-not-windows, test, security
+envlist = py{36,37-dev,py3}, lint, lint-not-windows, pip-check-reqs, test, security
 skipsdist = True
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 app = nim
@@ -9,6 +9,7 @@ use_develop = True
 
 [testenv:lint]
 commands =
+    pycodestyle {[tox]app}
     flake8 --max-line-length 99 --max-complexity 12 {[tox]app}
     # Ignore return code of Pylint for now to not make the build fail.
     # TODO: Remove the dash once we've fixed all the issues.
@@ -19,6 +20,9 @@ commands =
 deps =
     flake8
     pep257
+    # There's an issue with pycodestyle 2.4.0 and flake8
+    # See https://github.com/PyCQA/pycodestyle/issues/741
+    pycodestyle < 2.4.0
     pylint
 
 [testenv:lint-not-windows]
@@ -28,11 +32,15 @@ deps =
 # OSError: [WinError 193] %1 is not a valid Win32 application
 platform = linux|darwin
 commands =
-    # Ignore return code of eradicate for now to not make the build fail.
-    # TODO: Remove the dash once we've fixed all the issues.
-    - eradicate --recursive .
+    eradicate --recursive .
 deps =
     eradicate
+
+[testenv:pip-check-reqs]
+commands =
+    pip check
+deps =
+    -r{toxinidir}/requirements.txt
 
 [testenv:test]
 commands =
@@ -57,12 +65,12 @@ whitelist_externals = rm
 
 [testenv:security]
 commands =
-    # Ignore return code of Bandit for now to not make the build fail.
-    # TODO: Remove the dash once we've fixed all the issues.
-    - bandit -r {[tox]app} -c .bandit.yml
-    pyt -f {[tox]app}/app.py
+    bandit -r {[tox]app} -c .bandit.yml
+    pyt -f {[tox]app}/views.py
+    safety check -r requirements.txt
 deps =
     bandit
+    safety
     taint-analysis
 
 [testenv:cleanup]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37-dev,py3}, lint, lint-not-windows, pip-check-reqs, test, security
+envlist = py{36,37-dev,py3}, lint, not-windows, pip-check-reqs, test, security
 skipsdist = True
 skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 app = nim
@@ -25,16 +25,21 @@ deps =
     pycodestyle < 2.4.0
     pylint
 
-[testenv:lint-not-windows]
-# eradicate doesn't run on Windows, raising the following error:
-# ERROR: invocation failed (errno 8), args: ['C:\\projects\\nim\\.tox\\lint\\Scripts\\eradicate', '--recursive', '.'], cwd: C:\projects\nim
-# [...]
-# OSError: [WinError 193] %1 is not a valid Win32 application
+[testenv:not-windows]
 platform = linux|darwin
 commands =
+    # eradicate doesn't run on Windows, raising the following error:
+    # ERROR: invocation failed (errno 8), args: ['C:\\projects\\nim\\.tox\\lint\\Scripts\\eradicate', '--recursive', '.'], cwd: C:\projects\nim
+    # [...]
+    # OSError: [WinError 193] %1 is not a valid Win32 application
     eradicate --recursive .
+    # safety doesn't run on Windows, raising the following error:
+    # UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-79: character maps to <undefined>
+    # ERROR: InvocationError for command 'C:\\projects\\nim\\.tox\\security\\Scripts\\safety.EXE check -r requirements.txt' (exited with code 1)
+    safety check -r requirements.txt
 deps =
     eradicate
+    safety
 
 [testenv:pip-check-reqs]
 commands =
@@ -67,10 +72,8 @@ whitelist_externals = rm
 commands =
     bandit -r {[tox]app} -c .bandit.yml
     pyt -f {[tox]app}/views.py
-    safety check -r requirements.txt
 deps =
     bandit
-    safety
     taint-analysis
 
 [testenv:cleanup]


### PR DESCRIPTION
NIM-41 Fix bandit errors and stop ignoring its results

NIM-42 Fix eradicate errors and stop ignoring its results

Replace `run.py` with `run.sh` for a few reasons:
1. To stop calling `app.run()` with `debug=True`
2. To call `flask run` as recommended in the docs
3. To be able to set environment variables for Flask

Separate the app creation and the different routes in two files:
- `nim/__init__.py`: create the app
- `nim/views.py`: the routes (renamed from `nim/app.py` otherwise there
  would be an import conflict when trying to import the app)

Fix a couple of lines that were too long.

Run `pycodestyle`,`pip check` and `safety` because why not.