### PR TITLE
NIM-23 Better variable names

### DIFF
--- a/nim/game.py
+++ b/nim/game.py
@@ -4,11 +4,14 @@ from random import choice, randint
 
 from nim.exceptions import NimException
 
-NUM_LIMIT_MIN = 1
-NUM_LIMIT_MAX = 50
-DEFAULT_MIN = 5
-DEFAULT_MAX = 20
-DEFAULT_PILES = 3
+ABS_MIN_STONES_PER_PILE = 1
+ABS_MAX_STONES_PER_PILE = 50
+ABS_MIN_NUM_PILES = 1
+ABS_MAX_NUM_PILES = 50
+
+DEFAULT_MIN_STONES_PER_PILE = 5
+DEFAULT_MAX_STONES_PER_PILE = 20
+DEFAULT_NUM_PILES = 3
 
 
 class Bot():
@@ -99,19 +102,33 @@ class Nim():
         self.chaos = Chaos()
 
     @staticmethod
-    def new_game(min=DEFAULT_MIN, max=DEFAULT_MAX, piles=DEFAULT_PILES):
+    def new_game(min_stones_per_pile=DEFAULT_MIN_STONES_PER_PILE,
+                 max_stones_per_pile=DEFAULT_MAX_STONES_PER_PILE,
+                 num_piles=DEFAULT_NUM_PILES):
         """
-        Logic of new game dealt with here. Uses min, max & piles to return a
-        list of piles
+        Logic of new game dealt with here. Uses min_stones_per_pile,
+        max_stones_per_pile & num_piles to return a list of piles
         """
-        if not all(isinstance(x, int) and NUM_LIMIT_MIN <= x <= NUM_LIMIT_MAX
-                   for x in (min, max, piles)):
-            raise NimException(f"Please use integers between {NUM_LIMIT_MIN} "
-                               "and {NUM_LIMIT_MAX}")
-        elif min > max:
+        if not all(isinstance(x, int) and
+                   ABS_MIN_STONES_PER_PILE <= x <= ABS_MAX_STONES_PER_PILE
+                   for x in (min_stones_per_pile, max_stones_per_pile)):
             raise NimException(
-                f"Min({min}) cant be greater than Max({max})")
-        return [randint(min, max) for _ in range(piles)]
+                f"Please use integers between {ABS_MIN_STONES_PER_PILE} and "
+                "{ABS_MAX_STONES_PER_PILE} for the number of stones"
+            )
+        elif not (isinstance(num_piles, int) and
+                  ABS_MIN_NUM_PILES <= num_piles <= ABS_MAX_NUM_PILES):
+            raise NimException(
+                f"Please use an integer between {ABS_MIN_NUM_PILES} and "
+                "{ABS_MAX_NUM_PILES} for the number of piles"
+            )
+        elif min_stones_per_pile > max_stones_per_pile:
+            raise NimException(
+                f"min_stones_per_pile ({min_stones_per_pile}) can't be "
+                "greater than max_stones_per_pile ({max_stones_per_pile})"
+            )
+        return [randint(min_stones_per_pile, max_stones_per_pile)
+                for _ in range(num_piles)]
 
     def update(self, state, move):
         if not self.is_valid_move(state, move):

--- a/nim/static/game_operations.js
+++ b/nim/static/game_operations.js
@@ -10,9 +10,9 @@ function newGame() {
     type:"POST",
     url: "/new",
     data: JSON.stringify({
-      "min": parseInt($('#minPerPile').val()),
-      "max": parseInt($('#maxPerPile').val()),
-      "piles": parseInt($('#numPiles').val())
+      "min_stones_per_pile": parseInt($('#minStonesPerPile').val()),
+      "max_stones_per_pile": parseInt($('#maxStonesPerPile').val()),
+      "num_piles": parseInt($('#numPiles').val())
     }),
     contentType: contTypeJSON,
     dataType : 'json',

--- a/nim/templates/index.html
+++ b/nim/templates/index.html
@@ -48,12 +48,12 @@
     </div>
 
     <div>
-      <input type="number" id="minPerPile" value="4" min="1" onchange="newGame()">
+      <input type="number" id="minStonesPerPile" value="4" min="1" onchange="newGame()">
       minimum stones per pile
     </div>
 
     <div>
-      <input type="number" id="maxPerPile" value="12" min="1" onchange="newGame()">
+      <input type="number" id="maxStonesPerPile" value="12" min="1" onchange="newGame()">
       maximum stones per pile
     </div>
 

--- a/nim/tests/test_routes.py
+++ b/nim/tests/test_routes.py
@@ -5,11 +5,13 @@ import pytest  # pylint: disable=F0401
 
 from nim import app
 from nim.game import (
-    NUM_LIMIT_MIN,
-    NUM_LIMIT_MAX,
-    DEFAULT_MIN,
-    DEFAULT_MAX,
-    DEFAULT_PILES,
+    ABS_MIN_STONES_PER_PILE,
+    ABS_MAX_STONES_PER_PILE,
+    ABS_MIN_NUM_PILES,
+    ABS_MAX_NUM_PILES,
+    DEFAULT_MIN_STONES_PER_PILE,
+    DEFAULT_MAX_STONES_PER_PILE,
+    DEFAULT_NUM_PILES,
 )
 
 
@@ -19,20 +21,26 @@ def client_app():
 
 
 @pytest.mark.parametrize("request", [
-    # With valid min, max and piles
-    {'min': 5, 'max': 15, 'piles': 4},
-    # Without min
-    {'max': 15, 'piles': 4},
-    # Without max
-    {'min': 5, 'piles': 4},
-    # Without piles
-    {'min': 5, 'max': 15},
+    # With valid min_stones_per_pile, max_stones_per_pile and num_piles
+    {'min_stones_per_pile': 5, 'max_stones_per_pile': 15, 'num_piles': 4},
+    # Without min_stones_per_pile
+    {'max_stones_per_pile': 15, 'num_piles': 4},
+    # Without max_stones_per_pile
+    {'min_stones_per_pile': 5, 'num_piles': 4},
+    # Without num_piles
+    {'min_stones_per_pile': 5, 'max_stones_per_pile': 15},
     # Without any arguments
     {},
     # Max out the number of stones per pile
-    {'min': NUM_LIMIT_MAX, 'max': NUM_LIMIT_MAX},
+    {'min_stones_per_pile': ABS_MAX_STONES_PER_PILE,
+     'max_stones_per_pile': ABS_MAX_STONES_PER_PILE},
     # Max out the number of piles
-    {'piles': NUM_LIMIT_MAX},
+    {'num_piles': ABS_MAX_NUM_PILES},
+    # Minimum number of stones per pile
+    {'min_stones_per_pile': ABS_MIN_STONES_PER_PILE,
+     'max_stones_per_pile': ABS_MIN_STONES_PER_PILE},
+    # Minimum number of piles
+    {'num_piles': ABS_MIN_NUM_PILES},
 ])
 def test_new_game_success(client_app, request):
     """
@@ -52,34 +60,40 @@ def test_new_game_success(client_app, request):
     state = response['state']
     assert all(isinstance(x, int) for x in state)
     # Checking num piles returned is requested or default
-    assert request.get('piles', DEFAULT_PILES) == len(state)
-    # Check that min value was respected
-    assert NUM_LIMIT_MIN <= request.get('min', DEFAULT_MIN) <= min(state)
-    # Check that max value was respected
-    assert max(state) <= request.get('max', DEFAULT_MAX) <= NUM_LIMIT_MAX
+    assert request.get('num_piles', DEFAULT_NUM_PILES) == len(state)
+    # Check that min_stones_per_pile value was respected
+    min_stones_per_pile = request.get('min_stones_per_pile',
+                                      DEFAULT_MIN_STONES_PER_PILE)
+    assert ABS_MIN_STONES_PER_PILE <= min_stones_per_pile <= min(state)
+    # Check that max_stones_per_pile value was respected
+    max_stones_per_pile = request.get('max_stones_per_pile',
+                                      DEFAULT_MAX_STONES_PER_PILE)
+    assert max(state) <= max_stones_per_pile <= ABS_MAX_STONES_PER_PILE
 
 
 @pytest.mark.parametrize("request", [
-    # Too big value for min (passing max to satisfy min <= max)
-    {'min': NUM_LIMIT_MAX + 1, 'max': NUM_LIMIT_MAX + 1},
-    # Too big value for max
-    {'max': NUM_LIMIT_MAX + 1},
-    # Too big value for piles
-    {'piles': NUM_LIMIT_MAX + 1},
-    # Too small value for min
-    {'min': NUM_LIMIT_MIN - 1},
-    # Too small value for max
-    {'max': NUM_LIMIT_MIN - 1},
-    # Too small value for piles
-    {'piles': NUM_LIMIT_MIN - 1},
-    # Non int value for min
-    {'min': "a"},
-    # Non int value for max
-    {'max': "a"},
-    # Non int value for piles
-    {'piles': "a"},
-    # min greater than max
-    {'min': 30, 'max': 10},
+    # Too big value for min_stones_per_pile (passing max_stones_per_pile to
+    # satisfy min_stones_per_pile <= max_stones_per_pile)
+    {'min_stones_per_pile': ABS_MAX_STONES_PER_PILE + 1,
+     'max_stones_per_pile': ABS_MAX_STONES_PER_PILE + 1},
+    # Too big value for max_stones_per_pile
+    {'max_stones_per_pile': ABS_MAX_STONES_PER_PILE + 1},
+    # Too big value for num_piles
+    {'num_piles': ABS_MAX_NUM_PILES + 1},
+    # Too small value for min_stones_per_pile
+    {'min_stones_per_pile': ABS_MIN_STONES_PER_PILE - 1},
+    # Too small value for max_stones_per_pile
+    {'max_stones_per_pile': ABS_MIN_STONES_PER_PILE - 1},
+    # Too small value for num_piles
+    {'num_piles': ABS_MIN_NUM_PILES - 1},
+    # Non int value for min_stones_per_pile
+    {'min_stones_per_pile': "a"},
+    # Non int value for max_stones_per_pile
+    {'max_stones_per_pile': "a"},
+    # Non int value for num_piles
+    {'num_piles': "a"},
+    # min_stones_per_pile greater than max_stones_per_pile
+    {'min_stones_per_pile': 30, 'max_stones_per_pile': 10},
 ])
 def test_new_game_failed(client_app, request):
     """
@@ -101,11 +115,13 @@ def test_new_game_failed(client_app, request):
 
 def test_constants():
     """
-    Ensures DEFAULT constants for min, max & piles are in between min limit &
-    max limit constants
+    Ensures DEFAULT constants for min_stones_per_pile, max_stones_per_pile &
+    num_piles are within their absolute limits
     """
-    assert all(NUM_LIMIT_MIN <= x <= NUM_LIMIT_MAX
-               for x in (DEFAULT_MIN, DEFAULT_MAX, DEFAULT_PILES))
+    assert all(ABS_MIN_STONES_PER_PILE <= x <= ABS_MAX_STONES_PER_PILE
+               for x in (DEFAULT_MIN_STONES_PER_PILE,
+                         DEFAULT_MAX_STONES_PER_PILE))
+    assert ABS_MIN_NUM_PILES <= DEFAULT_NUM_PILES <= ABS_MAX_NUM_PILES
 
 
 def test_index(client_app):


### PR DESCRIPTION
Backend:

Use `min_stones_per_pile` instead of `min`
Use `max_stones_per_pile` instead of `max`
Use `num_piles` instead of `piles`
Use `ABS_MIN_STONES_PER_PILE` and `ABS_MIN_NUM_PILES` instead of `NUM_LIMIT_MIN`
Use `ABS_MAX_STONES_PER_PILE` and `ABS_MAX_NUM_PILES` instead of `NUM_LIMIT_MAX`
Use `DEFAULT_MIN_STONES_PER_PILE` instead of `DEFAULT_MIN`
Use `DEFAULT_MAX_STONES_PER_PILE` instead of `DEFAULT_MAX`
Use `DEFAULT_NUM_PILES` instead of `DEFAULT_PILES`

Plus a bit of formatting and tests for the new `ABS_*` variables

Frontend:

Use `minStonesPerPile` instead of `minPerPile`
Use `maxStonesPerPile` instead of `maxPerPile`