### PR TITLE
Show missing lines

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ deps =
 commands =
     # The -v option for pytest is required for the pytest-random-order package
     # to work.
-    pytest -v --spec --doctest-modules --cov={[tox]app} {[tox]app} {posargs}
+    pytest -v --spec --doctest-modules --cov={[tox]app} --cov-report=term-missing {[tox]app} {posargs}
     # Remove the file created by pytest-readme after running pytest
     rm -f test_readme.py
 deps =


### PR DESCRIPTION
Before:
```
$ tox -e test
[...]
----------- coverage: platform linux, python 3.6.5-final-0 -----------
Name                       Stmts   Miss  Cover
----------------------------------------------
nim/__init__.py                5      0   100%
nim/exceptions.py              2      0   100%
nim/game.py                   74     23    69%
nim/tests/__init__.py          0      0   100%
nim/tests/test_routes.py      30      0   100%
nim/tests/test_temp.py         9      0   100%
nim/views.py                  18      5    72%
----------------------------------------------
TOTAL                        138     28    80%
[...]
```

After:
```
$ tox -e test
[...]
----------- coverage: platform linux, python 3.6.5-final-0 -----------
Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
nim/__init__.py                5      0   100%
nim/exceptions.py              2      0   100%
nim/game.py                   74     23    69%   30, 38-40, 49-50, 58-59, 67-68, 77-78, 90-92, 134-136, 139-143
nim/tests/__init__.py          0      0   100%
nim/tests/test_routes.py      30      0   100%
nim/tests/test_temp.py         9      0   100%
nim/views.py                  18      5    72%   21-25
--------------------------------------------------------
TOTAL                        138     28    80%
[...]
```